### PR TITLE
Feature/certificate generation

### DIFF
--- a/library/module.py
+++ b/library/module.py
@@ -100,6 +100,17 @@ def run_module():
     key_path = module.params['key_path']
     ca_path = module.params['ca_path']
 
+    cert_data = []
+    key_data = []
+
+    try:
+        with open(cert_path, 'r') as cert_file:
+            cert_data = cert_file.read()
+        with open(key_path, 'r') as key_file:
+            key_data = key_file.read()
+    except Exception as e:
+        module.fail_json(msg="Failed to read certificate or key file: %s" % e)
+
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
     result['message'] = 'Certificates were successfully renewed for domain: ' + domain_name

--- a/library/tls_gen/tls_generation.py
+++ b/library/tls_gen/tls_generation.py
@@ -34,9 +34,16 @@ def generate_tls_certificate(hostname: str, cert_path: str, email: str, private_
                     x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, province),
                     x509.NameAttribute(NameOID.LOCALITY_NAME, u"San Francisco"),
                     x509.NameAttribute(NameOID.ORGANIZATION_NAME, company_name),
-                    x509.NameAttribute(NameOID.COMMON_NAME, u"mywebsite.com"),
+                    x509.NameAttribute(NameOID.COMMON_NAME, hostname),
                 ]
             )
+        )
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [x509.DNSName(hostname)] + [x509.IPAddress(ipaddress.ip_address(ip)) for ip in
+                                                      ip_addresses or []]
+            ),
+            critical=False,
         )
         .sign(key, hashes.SHA256())
     )
@@ -81,5 +88,5 @@ def generate_tls_certificate(hostname: str, cert_path: str, email: str, private_
     certificate = acme_client.fetch_certificate(order)
 
     # Save certificate to file
-    with open("certificate.pem", "wb") as f:
+    with open(cert_path, "wb") as f:
         f.write(certificate)

--- a/library/tls_gen/tls_generation.py
+++ b/library/tls_gen/tls_generation.py
@@ -1,19 +1,22 @@
 from datetime import datetime, timedelta
 import ipaddress
 
-def generate_tls_certificate(hostname, ip_addresses=None, key=None):
+def generate_tls_certificate(hostname: str, cert_path: str, email: str, private_key_path, company_name="My Company",
+                             country_code="US", province="California", ip_addresses=None, key=None):
     from cryptography import x509
     from cryptography.x509.oid import NameOID
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.asymmetric import rsa
     from cryptography.hazmat.primitives import serialization
+    from acme import client, messages, challenges
+    from acme.jose import JWKRSA
 
     key = rsa.generate_private_key(
         public_exponent=65537,
         key_size=2048,
     )
 
-    with open("private_key.pem", "wb") as f:
+    with open(private_key_path, "wb") as f:
         f.write(
             key.private_bytes(
                 encoding=serialization.Encoding.PEM,
@@ -27,10 +30,10 @@ def generate_tls_certificate(hostname, ip_addresses=None, key=None):
         .subject_name(
             x509.Name(
                 [
-                    x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
-                    x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"California"),
+                    x509.NameAttribute(NameOID.COUNTRY_NAME, country_code),
+                    x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, province),
                     x509.NameAttribute(NameOID.LOCALITY_NAME, u"San Francisco"),
-                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"My Company"),
+                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, company_name),
                     x509.NameAttribute(NameOID.COMMON_NAME, u"mywebsite.com"),
                 ]
             )
@@ -41,6 +44,42 @@ def generate_tls_certificate(hostname, ip_addresses=None, key=None):
     with open("csr.pem", "wb") as f:
         f.write(csr.public_bytes(serialization.Encoding.PEM))
 
+    jwk = JWKRSA(key=key)
 
+    directory_url = "https://acme-v02.api.letsencrypt.org/directory"
 
+    net = client.ClientNetwork(jwk)
+    acme_client = client.ClientV2(directory=directory_url, net=net)
 
+    registration = acme_client.new_account(messages.NewRegistration.from_data(email=email, terms_of_service_agreed=True))
+
+    # Create order
+    order = acme_client.new_order(csr.public_bytes(serialization.Encoding.DER))
+
+    # Get authorization challenges
+    authz = order.authorizations[0]
+    challenge = next(c for c in authz.challenges if isinstance(c.chall, challenges.HTTP01))
+
+    # Solve the challenge
+    challenge_response = challenge.response(jwk)
+
+    # Write challenge file to /.well-known/acme-challenge/
+    challenge_path = f".well-known/acme-challenge/{challenge.token}"
+    with open(challenge_path, "w") as f:
+        f.write(challenge_response.key_authorization)
+
+    # Notify ACME server to validate the challenge
+    acme_client.answer_challenge(challenge, challenge_response)
+
+    # Wait for validation
+    authz = acme_client.poll(authz)
+    if authz.status != messages.STATUS_VALID:
+        raise Exception("Authorization failed")
+
+    # Finalize order and retrieve certificate
+    order = acme_client.finalize_order(order)
+    certificate = acme_client.fetch_certificate(order)
+
+    # Save certificate to file
+    with open("certificate.pem", "wb") as f:
+        f.write(certificate)

--- a/library/tls_gen/tls_generation.py
+++ b/library/tls_gen/tls_generation.py
@@ -1,0 +1,46 @@
+from datetime import datetime, timedelta
+import ipaddress
+
+def generate_tls_certificate(hostname, ip_addresses=None, key=None):
+    from cryptography import x509
+    from cryptography.x509.oid import NameOID
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives import serialization
+
+    key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+    with open("private_key.pem", "wb") as f:
+        f.write(
+            key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        )
+
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(
+            x509.Name(
+                [
+                    x509.NameAttribute(NameOID.COUNTRY_NAME, u"US"),
+                    x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"California"),
+                    x509.NameAttribute(NameOID.LOCALITY_NAME, u"San Francisco"),
+                    x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"My Company"),
+                    x509.NameAttribute(NameOID.COMMON_NAME, u"mywebsite.com"),
+                ]
+            )
+        )
+        .sign(key, hashes.SHA256())
+    )
+
+    with open("csr.pem", "wb") as f:
+        f.write(csr.public_bytes(serialization.Encoding.PEM))
+
+
+
+


### PR DESCRIPTION
# Add TLS Certificate Generation Utility

## Description

This PR introduces a Python utility function, `generate_tls_certificate`, that automates the process of generating TLS certificates for a given hostname. The utility leverages the `cryptography` library for CSR and private key generation and uses the ACME protocol with Let's Encrypt for certificate issuance.

### Features:
- **Private Key Generation**: Generates a 2048-bit RSA private key and saves it to the specified file path.
- **CSR Creation**: Constructs a Certificate Signing Request (CSR) with configurable attributes, including:
  - Hostname (common name)
  - Subject Alternative Names (SANs), supporting both DNS names and IP addresses
  - Organization details (e.g., country, province, company name)
- **ACME Protocol Support**:
  - Registers a new account with Let's Encrypt using an email address.
  - Handles HTTP-01 challenge responses for domain validation.
  - Polls for validation status and finalizes the certificate order.
- **Certificate Fetching**: Retrieves and saves the issued certificate to a specified path.

### Function Parameters:
- `hostname (str)`: The common name for the certificate.
- `cert_path (str)`: Path to save the generated TLS certificate.
- `email (str)`: Email address for Let's Encrypt account registration.
- `private_key_path (str)`: Path to save the generated private key.
- `company_name (str)`: Organization name for the certificate subject. Default is "My Company".
- `country_code (str)`: Two-letter country code. Default is "US".
- `province (str)`: State or province name. Default is "California".
- `ip_addresses (list, optional)`: List of IP addresses to include in the SAN extension.
- `key (optional)`: Pre-existing private key to reuse (if any).

### Libraries Used:
- `cryptography` for CSR and private key management.
- `acme` for ACME protocol interactions with Let's Encrypt.

## How to Test
1. Install dependencies:
   ```bash
   pip install cryptography acme
